### PR TITLE
fixed predict.py issue: model loads from --model_dir 

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -26,13 +26,13 @@ def load_model(pred_config, args, device):
         raise Exception("Model doesn't exists! Train first!")
 
     try:
-        model = MODEL_CLASSES[args.model_type][1].from_pretrained(args.model_dir,
+        model = MODEL_CLASSES[args.model_type][1].from_pretrained(pred_config.model_dir,
                                                                   args=args,
                                                                   intent_label_lst=get_intent_labels(args),
                                                                   slot_label_lst=get_slot_labels(args))
         model.to(device)
         model.eval()
-        logger.info("***** Model Loaded *****")
+        logger.info(f"***** Model Loaded: {pred_config.model_dir} *****")
     except:
         raise Exception("Some model files might be missing...")
 


### PR DESCRIPTION
instead of a location specified at training time.

The fix is based on inconsistent rows # 25 (where the `model_path` is checked) and # 29 where it is used. The author's intention was most likely to rename `arg` -> `pred_config` and this operation was skipped for the line # 29.
This bug was triggered by the recording BestModel functionality -- model paths written into the `training_args.bin` file are always the same and equal to the main model path.